### PR TITLE
Build: Fix python site-packages path

### DIFF
--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -12,7 +12,7 @@ SET( SWIG_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/yui_python.cxx" )
 
 
 FIND_PACKAGE(PythonInterp)
-EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -s -S -c "import sys,site;sys.stdout.write(site.PREFIXES[0]+'/lib'+('/python'+str(sys.version_info.major)+'.'+str(sys.version_info.minor) if sys.platform.startswith('linux') else ''))" OUTPUT_VARIABLE PYTHON_LIB_DIR)
+EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c "import sys,site;sys.stdout.write(site.PREFIXES[0]+'/lib'+('/python'+str(sys.version_info.major)+'.'+str(sys.version_info.minor) if sys.platform.startswith('linux') else ''))" OUTPUT_VARIABLE PYTHON_LIB_DIR)
 
 IF (NOT PYTHON_SITEDIR)
 SET (PYTHON_SITEDIR ${PYTHON_LIB_DIR}/site-packages)

--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -12,7 +12,7 @@ SET( SWIG_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/yui_python.cxx" )
 
 
 FIND_PACKAGE(PythonInterp)
-EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c "import sys; sys.stdout.write(sys.path[2])" OUTPUT_VARIABLE PYTHON_LIB_DIR)
+EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -s -S -c "import sys,site;sys.stdout.write(site.PREFIXES[0]+'/lib'+('/python'+str(sys.version_info.major)+'.'+str(sys.version_info.minor) if sys.platform.startswith('linux') else ''))" OUTPUT_VARIABLE PYTHON_LIB_DIR)
 
 IF (NOT PYTHON_SITEDIR)
 SET (PYTHON_SITEDIR ${PYTHON_LIB_DIR}/site-packages)


### PR DESCRIPTION
During the build, your idea for getting the directory right above `site-packages` is

`````python
import sys; sys.stdout.write(sys.path[2])
`````

On most systems, `sys.path` is completely filled with all sorts of modules in all sorts of terrible locations (e.g. `$HOME/.local`, packages imported by [`site`](https://docs.python.org/2/library/site.html), etc.).

My suggestion on how to do it properly is only half-serious, but it adheres completely to the description in  the `site` module docs on how this path should be constructed.