### PR TITLE
Fix for System.EntryPointNotFoundException issue

### DIFF
--- a/swig/mono/CMakeLists.txt
+++ b/swig/mono/CMakeLists.txt
@@ -40,8 +40,8 @@ TARGET_LINK_LIBRARIES( yui_csharp ${LIBYUI_LIBRARY} )
 ADD_CUSTOM_COMMAND(
 	TARGET yui_csharp
 	POST_BUILD
-	COMMAND sed -i -e 's|DllImport\(\"yui\"|DllImport(\"\$\{MONO_LIBRARIES\}/yui/yui.so\"|g' "${CMAKE_CURRENT_BINARY_DIR}/yuiPINVOKE.cs" 
-)
+	COMMAND sed -i -e 's|DllImport\(\"yui\"|DllImport\(\"${MONO_LIBRARIES}/yui/yui.so\"|g' "${CMAKE_CURRENT_BINARY_DIR}/yuiPINVOKE.cs" )
+
 
 ADD_CUSTOM_COMMAND(
    TARGET yui_csharp POST_BUILD

--- a/swig/mono/CMakeLists.txt
+++ b/swig/mono/CMakeLists.txt
@@ -24,6 +24,7 @@ ADD_CUSTOM_COMMAND (
    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../*.i
 )
 
+
 SET(yui_csharp_SRCS ${SWIG_OUTPUT} )
 
 ADD_LIBRARY( yui_csharp SHARED ${yui_csharp_SRCS} )
@@ -32,6 +33,15 @@ ADD_LIBRARY( yui_csharp SHARED ${yui_csharp_SRCS} )
 SET_TARGET_PROPERTIES( yui_csharp PROPERTIES PREFIX "" OUTPUT_NAME "yui")
 
 TARGET_LINK_LIBRARIES( yui_csharp ${LIBYUI_LIBRARY} )
+
+#
+# WORKAROUND: replace DllImport("yui" with DllImport("/abs_path/yui.so"
+#
+ADD_CUSTOM_COMMAND(
+	TARGET yui_csharp
+	POST_BUILD
+	COMMAND sed -i -e 's|DllImport\(\"yui\"|DllImport(\"\$\{MONO_LIBRARIES\}/yui/yui.so\"|g' "${CMAKE_CURRENT_BINARY_DIR}/yuiPINVOKE.cs" 
+)
 
 ADD_CUSTOM_COMMAND(
    TARGET yui_csharp POST_BUILD


### PR DESCRIPTION
Hello,
this patch fixes the EntryPointNotFoundException (issue #18 ) by using the installation path for the shared object instead of the sole basename of the library.
I've done some test and it properly works locally (Mageia, mcs version 3.12.1.0, monodevelop 5.7).

Regards,
matteo