### PR TITLE
Fix build with ruby 3.0

### DIFF
--- a/swig/yui.i
+++ b/swig/yui.i
@@ -277,7 +277,7 @@ class Exception;
 
 #if defined(SWIGRUBY)
 %extend YEvent {
-  VALUE mywidget() { return INT2FIX( $self->widget() ); }
+  VALUE mywidget() { return INT2FIX( (long)$self->widget() ); }
 }
 #endif
 


### PR DESCRIPTION
Currently compiling with ruby 3.0 fails with

```
/builddir/build/BUILD/libyui-bindings-59dfa64f05adb40c7da88325255d758f4588ab42/x86_64-redhat-linux-gnu/swig/ruby/yui_ruby.cxx: In function 'VALUE YEvent_mywidget(YEvent*)':
/builddir/build/BUILD/libyui-bindings-59dfa64f05adb40c7da88325255d758f4588ab42/x86_64-redhat-linux-gnu/swig/ruby/yui_ruby.cxx:3287:77: error: invalid conversion from 'YWidget*' to 'long int' [-fpermissive]
 3287 | SWIGINTERN VALUE YEvent_mywidget(YEvent *self){ return INT2FIX( self->widget() ); }
      |                                                                 ~~~~~~~~~~~~^~
      |                                                                             |
      |                                                                             YWidget*
In file included from /usr/include/ruby/internal/arithmetic/int.h:26,
                 from /usr/include/ruby/internal/arithmetic/char.h:23,
                 from /usr/include/ruby/internal/arithmetic.h:23,
                 from /usr/include/ruby/ruby.h:25,
                 from /usr/include/ruby.h:38,
                 from /builddir/build/BUILD/libyui-bindings-59dfa64f05adb40c7da88325255d758f4588ab42/x86_64-redhat-linux-gnu/swig/ruby/yui_ruby.cxx:880:
/usr/include/ruby/internal/arithmetic/long.h:82:17: note:   initializing argument 1 of 'constexpr VALUE RB_INT2FIX(long int)'
   82 | RB_INT2FIX(long i)
```

With ruby 3.0, INT2FIX definition is expanded to RB_INT2FIX, which is actually defined as function
instead of macro which was on ruby 2.7, and with compiling as C++, explicit cast from pointer to
long is needed.